### PR TITLE
 Facility to not skip certain specific specific paths

### DIFF
--- a/src/uk/ac/open/lts/filecopier/Main.java
+++ b/src/uk/ac/open/lts/filecopier/Main.java
@@ -23,6 +23,7 @@ import java.awt.event.*;
 import java.io.*;
 import java.nio.file.*;
 import java.util.*;
+import java.util.List;
 import java.util.regex.*;
 
 import javax.swing.*;
@@ -42,7 +43,7 @@ public class Main extends JFrame implements ActionQueue.Handler
 		error = false, showingError = false, debug = false;
 	private Set<Watcher> waitingStartup = new HashSet<Watcher>();
 
-	private static String VERSION = "1.12";
+	private static String VERSION = "1.13";
 	private static int MAX_LINES = 500;
 
 	/**
@@ -67,9 +68,12 @@ public class Main extends JFrame implements ActionQueue.Handler
 	{
 		Color.MAGENTA, Color.CYAN, Color.YELLOW
 	}; 
-	
-	public final static HashSet<String> SKIP_FOLDERS = new HashSet<String>(
+
+	private final static HashSet<String> SKIP_FOLDERS = new HashSet<String>(
 		Arrays.asList(new String[] { ".git", ".idea", "vendor", "node_modules" }));
+
+	private final static List<String> DO_NOT_SKIP_PATH_SEGMENTS =
+			Arrays.asList(new String[] { "question/type/stack/question/type/stack/thirdparty/php-peg/lib/vendor" });
 
 	public Main()
 	{
@@ -421,5 +425,23 @@ public class Main extends JFrame implements ActionQueue.Handler
 				updateStatus();
 			}
 		});
+	}
+
+	public static boolean shouldSkipPath(Path path)
+	{
+		if (!SKIP_FOLDERS.contains(path.getFileName().toString()))
+		{
+			// Not a skip folder.
+			return false;
+		}
+		// Looks like a skip folder, is it an exception?
+		for (String exceptedPath : DO_NOT_SKIP_PATH_SEGMENTS)
+		{
+			if (path.endsWith(exceptedPath))
+			{
+				return false;
+			}
+		}
+		return true;
 	}
 }

--- a/src/uk/ac/open/lts/filecopier/Watcher.java
+++ b/src/uk/ac/open/lts/filecopier/Watcher.java
@@ -141,7 +141,7 @@ class Watcher extends Thread
 						public FileVisitResult preVisitDirectory(Path path,
 							BasicFileAttributes attr) throws IOException
 						{
-							if(Main.SKIP_FOLDERS.contains(path.getFileName().toString()))
+							if(Main.shouldSkipPath(path))
 							{
 								return FileVisitResult.SKIP_SUBTREE;
 							}
@@ -216,7 +216,7 @@ class Watcher extends Thread
 							// Don't do folders we are skipping.
 							for(int i=0; i<relative.getNameCount(); i++)
 							{
-								if(Main.SKIP_FOLDERS.contains(relative.getName(i).toString()))
+								if(Main.shouldSkipPath(relative))
 								{
 									continue eventLoop;
 								}
@@ -347,7 +347,7 @@ class Watcher extends Thread
 					public FileVisitResult preVisitDirectory(Path dir,
 						BasicFileAttributes attrs) throws IOException
 					{
-						if(Main.SKIP_FOLDERS.contains(dir.getFileName().toString()))
+						if(Main.shouldSkipPath(dir))
 						{
 							return FileVisitResult.SKIP_SUBTREE;
 						}


### PR DESCRIPTION
Required by qtype_stack, which contains a directory called 'vendor'.

I'm not 100% sure that this acutally works, but I cannot face waiting for another Wipe-and-recopy to run. I made some unit tests for shouldSkipPath and they passed. (Tests not included here, becuase nothing else in the project uses JUnit yet.)